### PR TITLE
fix: remove redundant detail:: prefix for Sample<Stat> in namespace b…

### DIFF
--- a/src/braft/util.cpp
+++ b/src/braft/util.cpp
@@ -47,7 +47,7 @@ namespace detail {
 typedef PercentileSamples<1022> CombinedPercentileSamples;
 
 static int64_t get_window_recorder_qps(void* arg) {
-    detail::Sample<Stat> s;
+    Sample<Stat> s;
     static_cast<RecorderWindow*>(arg)->get_span(1, &s);
     // Use floating point to avoid overflow.
     if (s.time_us <= 0) {


### PR DESCRIPTION
…var::detail

brpc 1.16.0 moved Sample struct from bvar::detail::detail to bvar::detail, causing compilation error when referenced as detail::Sample inside the bvar::detail namespace.